### PR TITLE
Use find_dependency(Threads)

### DIFF
--- a/packaging/PortMidiConfig.cmake.in
+++ b/packaging/PortMidiConfig.cmake.in
@@ -7,7 +7,7 @@ endif()
 
 if(NOT WIN32)
   set(THREADS_PREFER_PTHREAD_FLAG ON)
-  find_package(Threads REQUIRED)
+  find_dependency(Threads)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/PortMidiTargets.cmake")


### PR DESCRIPTION
`find_package(PortMidi)` without `REQUIRED` shall not fail. (Unlikely with Threads, but it is better to use a consistent pattern.)

Amends a47be8c.